### PR TITLE
from __future__ import print_function so print works same for Python 2&3

### DIFF
--- a/AnatomyOfMatplotlib-Part0-Intro2NumPy.ipynb
+++ b/AnatomyOfMatplotlib-Part0-Intro2NumPy.ipynb
@@ -1,13 +1,24 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:90ccb5909624353434d7af8f1073a89ba8f8f43775a430cf536d07701670eb19"
+  "signature": "sha256:291c02e0eda1008690ba35d47865fd743d899737c6c702e384430e08988052a0"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
  "worksheets": [
   {
    "cells": [
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "# Let printing work the same in Python 2 and 3\n",
+      "from __future__ import print_function"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
     {
      "cell_type": "markdown",
      "metadata": {},
@@ -39,9 +50,9 @@
      "collapsed": false,
      "input": [
       "a = np.array([1, 2, 3])\n",
-      "print a.shape\n",
-      "print a.size\n",
-      "print a.ndim"
+      "print(a.shape)\n",
+      "print(a.size)\n",
+      "print(a.ndim)"
      ],
      "language": "python",
      "metadata": {},
@@ -52,9 +63,9 @@
      "collapsed": false,
      "input": [
       "x = np.arange(100)\n",
-      "print x.shape\n",
-      "print x.size\n",
-      "print x.ndim"
+      "print(x.shape)\n",
+      "print(x.size)\n",
+      "print(x.ndim)"
      ],
      "language": "python",
      "metadata": {},
@@ -65,9 +76,9 @@
      "collapsed": false,
      "input": [
       "y = np.random.rand(5, 80)\n",
-      "print y.shape\n",
-      "print y.size\n",
-      "print y.ndim"
+      "print(y.shape)\n",
+      "print(y.size)\n",
+      "print(y.ndim)"
      ],
      "language": "python",
      "metadata": {},
@@ -86,7 +97,7 @@
      "collapsed": false,
      "input": [
       "x.shape = (20, 5)\n",
-      "print x"
+      "print(x)"
      ],
      "language": "python",
      "metadata": {},
@@ -104,7 +115,7 @@
      "collapsed": false,
      "input": [
       "y.shape = (4, 20, -1)\n",
-      "print y.shape"
+      "print(y.shape)"
      ],
      "language": "python",
      "metadata": {},
@@ -122,7 +133,7 @@
      "collapsed": false,
      "input": [
       "# Scalar Indexing\n",
-      "print x[2]"
+      "print(x[2])"
      ],
      "language": "python",
      "metadata": {},
@@ -133,7 +144,7 @@
      "collapsed": false,
      "input": [
       "# Slicing\n",
-      "print x[2:5]"
+      "print(x[2:5])"
      ],
      "language": "python",
      "metadata": {},
@@ -144,10 +155,10 @@
      "collapsed": false,
      "input": [
       "# Advanced slicing\n",
-      "print \"First 5 rows\\n\", x[:5]\n",
-      "print \"Row 18 to the end\\n\", x[18:]\n",
-      "print \"Last 5 rows\\n\", x[-5:]\n",
-      "print \"Reverse the rows\\n\", x[::-1]"
+      "print(\"First 5 rows\\n\", x[:5])\n",
+      "print(\"Row 18 to the end\\n\", x[18:])\n",
+      "print(\"Last 5 rows\\n\", x[-5:])\n",
+      "print(\"Reverse the rows\\n\", x[::-1])"
      ],
      "language": "python",
      "metadata": {},
@@ -158,7 +169,7 @@
      "collapsed": false,
      "input": [
       "# Boolean Indexing\n",
-      "print x[(x % 2) == 0]"
+      "print(x[(x % 2) == 0])"
      ],
      "language": "python",
      "metadata": {},
@@ -169,7 +180,7 @@
      "collapsed": false,
      "input": [
       "# Fancy Indexing -- Note the use of a list, not tuple!\n",
-      "print x[[1, 3, 8, 9, 2]]"
+      "print(x[[1, 3, 8, 9, 2]])"
      ],
      "language": "python",
      "metadata": {},
@@ -187,8 +198,8 @@
      "cell_type": "code",
      "collapsed": true,
      "input": [
-      "print \"Shape of X:\", x.shape\n",
-      "print \"Shape of Y:\", y.shape"
+      "print(\"Shape of X:\", x.shape)\n",
+      "print(\"Shape of Y:\", y.shape)"
      ],
      "language": "python",
      "metadata": {},
@@ -206,13 +217,13 @@
      "collapsed": false,
      "input": [
       "a = x + y\n",
-      "print a.shape\n",
+      "print(a.shape)\n",
       "b = x[np.newaxis, :, :] + y\n",
-      "print b.shape\n",
+      "print(b.shape)\n",
       "c = np.tile(x, (4, 1, 1)) + y\n",
-      "print c.shape\n",
-      "print \"Are a and b identical?\", np.all(a == b)\n",
-      "print \"Are a and c identical?\", np.all(a == c)"
+      "print(c.shape)\n",
+      "print(\"Are a and b identical?\", np.all(a == b))\n",
+      "print(\"Are a and c identical?\", np.all(a == c))"
      ],
      "language": "python",
      "metadata": {},
@@ -231,9 +242,9 @@
      "input": [
       "x = np.arange(-5, 5, 0.1)\n",
       "y = np.arange(-8, 8, 0.25)\n",
-      "print x.shape, y.shape\n",
+      "print(x.shape, y.shape)\n",
       "z = x[np.newaxis, :] * y[:, np.newaxis]\n",
-      "print z.shape"
+      "print(z.shape)"
      ],
      "language": "python",
      "metadata": {},
@@ -245,9 +256,9 @@
      "input": [
       "# More concisely\n",
       "y, x = np.ogrid[-8:8:0.25, -5:5:0.1]\n",
-      "print x.shape, y.shape\n",
+      "print(x.shape, y.shape)\n",
       "z = x * y\n",
-      "print z.shape"
+      "print(z.shape)"
      ],
      "language": "python",
      "metadata": {},

--- a/AnatomyOfMatplotlib-Part1-pyplot.ipynb
+++ b/AnatomyOfMatplotlib-Part1-pyplot.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:c7159e6f4ecac56d72f7333ed9bb24bbfeb4c66fba3000a1b2cb3c382fd148fd"
+  "signature": "sha256:6302a88e9db31d8d9cfae2b0103e57708f94b802a561930d11298cd246e9d590"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -12,6 +12,8 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
+      "# Let printing work the same in Python 2 and 3\n",
+      "from __future__ import print_function\n",
       "# Turning on inline plots -- just for use in ipython notebooks.\n",
       "%matplotlib inline"
      ],
@@ -64,8 +66,8 @@
      "collapsed": false,
      "input": [
       "import matplotlib\n",
-      "print matplotlib.__version__\n",
-      "print matplotlib.get_backend()"
+      "print(matplotlib.__version__)\n",
+      "print(matplotlib.get_backend())"
      ],
      "language": "python",
      "metadata": {},

--- a/AnatomyOfMatplotlib-Part2-HowToSpeakMPL.ipynb
+++ b/AnatomyOfMatplotlib-Part2-HowToSpeakMPL.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:e1f772cda181207fb767d95705c04a7a3d95f8d83188cf282ca42ddd7bde2d9c"
+  "signature": "sha256:fd78007a40ee7741b1dcfaa7d2433f856d967b938376774e12322eeccaf2f9ec"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -12,6 +12,8 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
+      "# Let printing work the same in Python 2 and 3\n",
+      "from __future__ import print_function\n",
       "# Turning on inline plots -- just for use in ipython notebooks.\n",
       "%matplotlib inline\n",
       "import numpy as np\n",
@@ -574,7 +576,7 @@
      "collapsed": false,
      "input": [
       "import matplotlib\n",
-      "print matplotlib.matplotlib_fname()"
+      "print(matplotlib.matplotlib_fname())"
      ],
      "language": "python",
      "metadata": {},

--- a/AnatomyOfMatplotlib-Part3-Artists.ipynb
+++ b/AnatomyOfMatplotlib-Part3-Artists.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:8e508bf3316b2a5e920e25f9597d595277a37bede03ba337428c5c16762373a7"
+  "signature": "sha256:0ed463ce3e3c15589941f95292232da728af5c8fd4698e2ece99a953d2619171"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -12,6 +12,8 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
+      "# Let printing work the same in Python 2 and 3\n",
+      "from __future__ import print_function\n",
       "# Turning on inline plots -- just for use in ipython notebooks.\n",
       "%matplotlib inline\n",
       "import numpy as np\n",
@@ -171,7 +173,7 @@
      "collapsed": false,
      "input": [
       "fig, ax = plt.subplots(1, 1)\n",
-      "print plt.getp(fig.patch)"
+      "print(plt.getp(fig.patch))"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
Just finished going through the notebooks with Python3 and everything worked fine except for having to manually modify all the print statements. Figured it could be made to seamlessly work with both Python 2 and 3 by simply using a `from __future__ import print_function`.
