### PR TITLE
Updated with changes as per newer matplotlib api to remove deprecation warning

### DIFF
--- a/AnatomyOfMatplotlib-Part2-Plotting_Methods_Overview.ipynb
+++ b/AnatomyOfMatplotlib-Part2-Plotting_Methods_Overview.ipynb
@@ -116,7 +116,7 @@
     "# We could have also done this with two separate calls to `ax.bar` and numpy boolean indexing.\n",
     "for bar, height in zip(vert_bars, y):\n",
     "    if height < 0:\n",
-    "        bar.set(edgecolor='darkred', color='salmon', linewidth=3)\n",
+    "        bar.set(color='salmon', edgecolor='darkred', linewidth=3)\n",
     "\n",
     "plt.show()"
    ]


### PR DESCRIPTION
Updated `bar.set(color='salmon', edgecolor='darkred', linewidth=3)` to pass `color` before `edgecolor` to fix `MatplotlibDeprecationWarning`